### PR TITLE
Potential fix for code scanning alert no. 4: Stored cross-site scripting

### DIFF
--- a/src/components/mdx/ArticleListItem.tsx
+++ b/src/components/mdx/ArticleListItem.tsx
@@ -8,10 +8,15 @@ type Props = {
 };
 
 export function ArticleListItem({ article, urlPrefix }: Props) {
+  const safeSlug = article.slug
+    .split('/')
+    .map((segment) => encodeURIComponent(segment))
+    .join('/');
+
   return (
     <li>
       <Link
-        href={`${urlPrefix}/${article.slug}`}
+        href={`${urlPrefix}/${safeSlug}`}
         className="group flex flex-col gap-1 py-3 no-underline"
       >
         <div className="flex items-baseline justify-between gap-4">


### PR DESCRIPTION
Potential fix for [https://github.com/powersagitar/mssg/security/code-scanning/4](https://github.com/powersagitar/mssg/security/code-scanning/4)

To fix this safely without changing intended behavior, encode each URL path segment of `article.slug` before building `href`. This preserves normal slugs while preventing special characters from altering URL semantics.

Best change:
- File: `src/components/mdx/ArticleListItem.tsx`
- In `ArticleListItem`, compute a safe slug from `article.slug` by splitting on `/`, applying `encodeURIComponent` to each segment, and joining back with `/`.
- Use that safe slug in the `href` template.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
